### PR TITLE
Added AnonInfo and Info::registerByReflection

### DIFF
--- a/src/SOFe/InfoAPI/AnonInfo.php
+++ b/src/SOFe/InfoAPI/AnonInfo.php
@@ -42,6 +42,7 @@ abstract class AnonInfo extends Info {
 	 *
 	 * @param string              $namespace the name of your plugin, optionally followed by `.module` if the plugin contains many modules
 	 * @param array<string, Info> $data
+	 * @param ?list<Info>         $fallbacks
 	 */
 	final public function __construct(string $namespace, private array $data,  ?array $fallbacks = null) {
 		$fallbacks = $fallbacks ?? [new CommonInfo(Server::getInstance())];
@@ -54,6 +55,7 @@ abstract class AnonInfo extends Info {
 			AnonInfo::$registered[$self] = true;
 
 			foreach($$data as $key => $value) {
+				/** @var class-string<Info> $to */
 				$to = get_class($value);
 				InfoAPI::provideInfo($self, $to, "$namespace.$key",
 					static function($instance) use($key) {

--- a/src/SOFe/InfoAPI/AnonInfo.php
+++ b/src/SOFe/InfoAPI/AnonInfo.php
@@ -44,7 +44,7 @@ abstract class AnonInfo extends Info {
 	 * @param array<string, Info> $data
 	 * @param ?list<Info>         $fallbacks
 	 */
-	final public function __construct(string $namespace, private array $data,  ?array $fallbacks = null) {
+	final public function __construct(string $namespace, private array $data,  ?array $fallbacks = null, ?InfoAPI $api = null) {
 		$fallbacks = $fallbacks ?? [new CommonInfo(Server::getInstance())];
 		foreach($fallbacks as $fallback) {
 			$this->fallbacks[get_class($fallback)] = $fallback;
@@ -54,14 +54,13 @@ abstract class AnonInfo extends Info {
 		if(!isset(AnonInfo::$registered[$self])) {
 			AnonInfo::$registered[$self] = true;
 
-			foreach($$data as $key => $value) {
+			foreach($data as $key => $value) {
 				/** @var class-string<Info> $to */
 				$to = get_class($value);
 				InfoAPI::provideInfo($self, $to, "$namespace.$key",
 					static function($instance) use($key) {
 						return $instance->data[$key];
-					},
-				);
+					}, $api);
 			}
 
 			foreach($this->fallbacks as $value) {
@@ -69,7 +68,7 @@ abstract class AnonInfo extends Info {
 				InfoAPI::provideFallback($self, $to,
 					static function($instance) use($to) {
 						return $instance->fallbacks[$to];
-					});
+					}, $api);
 			}
 		}
 	}

--- a/src/SOFe/InfoAPI/AnonInfo.php
+++ b/src/SOFe/InfoAPI/AnonInfo.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * InfoAPI
+ *
+ * Copyright (C) 2019-2021 SOFe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace SOFe\InfoAPI;
+
+use pocketmine\Server;
+use RuntimeException;
+
+use function get_class;
+
+abstract class AnonInfo extends Info {
+	/** @phpstan-var array<string, true> */
+	private static array $registered = [];
+	/** @phpstan-var array<class-string, Info> */
+	private array $fallbacks = [];
+
+	public function toString() : string {
+		throw new RuntimeException("AnonInfo must not be returned as a provided info");
+	}
+
+	/**
+	 * Creates a new instance from an associative array.
+	 *
+	 * @param string              $namespace the name of your plugin, optionally followed by `.module` if the plugin contains many modules
+	 * @param array<string, Info> $data
+	 */
+	final public function __construct(string $namespace, private array $data,  ?array $fallbacks = null) {
+		$fallbacks = $fallbacks ?? [new CommonInfo(Server::getInstance())];
+		foreach($fallbacks as $fallback) {
+			$this->fallbacks[get_class($fallback)] = $fallback;
+		}
+
+		$self = get_class($this);
+		if(!isset(AnonInfo::$registered[$self])) {
+			AnonInfo::$registered[$self] = true;
+
+			foreach($$data as $key => $value) {
+				$to = get_class($value);
+				InfoAPI::provideInfo($self, $to, "$namespace.$key",
+					static function($instance) use($key) {
+						return $instance->data[$key];
+					},
+				);
+			}
+
+			foreach($this->fallbacks as $value) {
+				$to = get_class($value);
+				InfoAPI::provideFallback($self, $to,
+					static function($instance) use($to) {
+						return $instance->fallbacks[$to];
+					});
+			}
+		}
+	}
+}

--- a/src/SOFe/InfoAPI/ContextInfo.php
+++ b/src/SOFe/InfoAPI/ContextInfo.php
@@ -40,7 +40,7 @@ use pocketmine\utils\Utils;
 /**
  * @deprecated Use AnonInfo or SimpleInfo instead.
  * @see AnonInfo
- * @link SimpleInfo
+ * @see SimpleInfo
  */
 abstract class ContextInfo extends Info {
 	/** @phpstan-var array<string, true> */

--- a/src/SOFe/InfoAPI/ContextInfo.php
+++ b/src/SOFe/InfoAPI/ContextInfo.php
@@ -39,7 +39,7 @@ use pocketmine\utils\Utils;
 
 /**
  * @deprecated Use AnonInfo or SimpleInfo instead.
- * @link AnonInfo
+ * @see AnonInfo
  * @link SimpleInfo
  */
 abstract class ContextInfo extends Info {

--- a/src/SOFe/InfoAPI/ContextInfo.php
+++ b/src/SOFe/InfoAPI/ContextInfo.php
@@ -37,6 +37,11 @@ use RuntimeException;
 use pocketmine\Server;
 use pocketmine\utils\Utils;
 
+/**
+ * @deprecated Use AnonInfo or SimpleInfo instead.
+ * @link AnonInfo
+ * @link SimpleInfo
+ */
 abstract class ContextInfo extends Info {
 	/** @phpstan-var array<string, true> */
 	private static array $registered = [];

--- a/src/SOFe/InfoAPI/Info.php
+++ b/src/SOFe/InfoAPI/Info.php
@@ -61,7 +61,7 @@ abstract class Info {
 
 			$type = $property->getType();
 			if(!($type instanceof ReflectionNamedType)) {
-				throw new ReflectionException("Property $property is untyped");
+				throw new ReflectionException("Property $property does not have a valid type");
 			}
 
 			/** @var class-string<Info> $target */

--- a/src/SOFe/InfoAPI/Info.php
+++ b/src/SOFe/InfoAPI/Info.php
@@ -64,6 +64,7 @@ abstract class Info {
 				throw new ReflectionException("Property $property is untyped");
 			}
 
+			/** @var class-string<Info> $target */
 			$target = $type->getName();
 			$targetClass = new ReflectionClass($target);
 			if(!($targetClass->isSubclassOf(Info::class))) {

--- a/src/SOFe/InfoAPI/Info.php
+++ b/src/SOFe/InfoAPI/Info.php
@@ -68,7 +68,7 @@ abstract class Info {
 			$target = $type->getName();
 			$targetClass = new ReflectionClass($target);
 			if(!($targetClass->isSubclassOf(Info::class))) {
-				throw new ReflectionException("Property $property is untyped");
+				throw new ReflectionException("Property $property does not have a valid type");
 			}
 
 			InfoAPI::provideInfo($class, $target, "$namespace." . $property->getName(), function(Info $info) use($property) : ?Info {

--- a/src/SOFe/InfoAPI/Info.php
+++ b/src/SOFe/InfoAPI/Info.php
@@ -22,6 +22,10 @@ declare(strict_types=1);
 
 namespace SOFe\InfoAPI;
 
+use ReflectionClass;
+use ReflectionException;
+use ReflectionNamedType;
+
 use function array_slice;
 use function explode;
 use function get_class;
@@ -42,5 +46,33 @@ abstract class Info {
 	static public function getInfoType() : string {
 		$comps = explode("\\", static::class);
 		return array_slice($comps, -1)[0];
+	}
+
+	/**
+	 * @param class-string<Info> $class
+	 */
+	static public function registerByReflection(string $namespace, string $class, ?int $filter = null, ?InfoAPI $api = null) : void {
+		$reflect = new ReflectionClass($class);
+
+		foreach($reflect->getProperties($filter) as $property) {
+			if($property->isStatic() || !$property->isPublic()) {
+				continue;
+			}
+
+			$type = $property->getType();
+			if(!($type instanceof ReflectionNamedType)) {
+				throw new ReflectionException("Property $property is untyped");
+			}
+
+			$target = $type->getName();
+			$targetClass = new ReflectionClass($target);
+			if(!($targetClass->isSubclassOf(Info::class))) {
+				throw new ReflectionException("Property $property is untyped");
+			}
+
+			InfoAPI::provideInfo($class, $target, "$namespace." . $property->getName(), function(Info $info) use($property) : ?Info {
+				return $property->getValue($info);
+			}, $api);
+		}
 	}
 }

--- a/tests/AnonInfoTest.php
+++ b/tests/AnonInfoTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * InfoAPI
+ *
+ * Copyright (C) 2019-2021 SOFe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace SOFe\InfoAPI;
+
+use PHPUnit\Framework\TestCase;
+
+final class AnonInfoTest extends TestCase {
+	public function test() : void {
+		$api = InfoAPI::createForTesting();
+
+		Defaults::initAll($api);
+		$string = InfoAPI::resolve("{one ordinal} {test.two ordinal}", new class("test", [
+			"one" => new NumberInfo(1.0),
+			"two" => new NumberInfo(2.0),
+		], [], $api) extends AnonInfo{}, false, $api);
+		self::assertSame("1st 2nd", $string);
+	}
+}


### PR DESCRIPTION
Deprecates the original `ContextInfo` in favour of either anonymously declared classes with array-based infos and normally declared classes with (probably promoted) public class properties.